### PR TITLE
fix: 🐛 Update copyright date in footer component. Fixes #20

### DIFF
--- a/src/components/trss-ucsc-footer/trss-ucsc-footer.tsx
+++ b/src/components/trss-ucsc-footer/trss-ucsc-footer.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from '@stencil/core';
+import { Component, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'trss-ucsc-footer',
@@ -8,6 +8,8 @@ import { Component, h } from '@stencil/core';
   scoped: true
 })
 export class TrssUcscFooter {
+
+  @Prop() year: string = new Date().getFullYear().toString();
 
   render() {
     return (
@@ -27,7 +29,7 @@ export class TrssUcscFooter {
                 <li><a href="https://jobs.ucsc.edu">Employment</a></li>
                 <li><a href="https://its.ucsc.edu/terms/">Privacy</a></li>
                 <li><a href="https://academicaffairs.ucsc.edu/accreditation/">Accreditation</a></li>
-                <li>&copy;2023 UC Regents</li>
+                <li>&copy;{this.year} UC Regents</li>
               </ul>
             </div>
 


### PR DESCRIPTION
Add a JS date calculation so the footer component always displays the current year.